### PR TITLE
Fix updateables bug

### DIFF
--- a/Game1.cs
+++ b/Game1.cs
@@ -90,6 +90,7 @@ namespace LegendOfZelda
             //new AnimationTester();
 
             controller = new PlayerController((Link)link);
+            new ProjectileTest();
         }
 
         protected override void Update(GameTime gameTime)

--- a/Level/LevelMaster.cs
+++ b/Level/LevelMaster.cs
@@ -115,9 +115,14 @@ namespace LegendOfZelda
         }
         public static void Update(GameTime gameTime)
         {
-            for (int i = CurrentRoomUpdateables.Count - 1; i >= 0; i--)
+            //Create unchangeable list of updateables
+            List<IUpdateable> thisFrameUpdates = CurrentRoomUpdateables.ToList();
+            for (int i = thisFrameUpdates.Count - 1; i >= 0; i--)
             {
-                CurrentRoomUpdateables[i].Update(gameTime);
+                if (thisFrameUpdates[i] != null)
+                {
+                    thisFrameUpdates[i].Update(gameTime);
+                }
             }
         }
         public static void Draw()

--- a/Projectiles/SwordBeamBurstProjectile.cs
+++ b/Projectiles/SwordBeamBurstProjectile.cs
@@ -79,7 +79,8 @@ namespace LegendOfZelda.Projectiles
         public void Destroy()
         {
             sprite.UnregisterSprite();
-            LevelMaster.RemoveUpdateable(this);
+            LevelMaster.RemoveCollider(collider);
+            collider.Active = false;
         }
 
         public void OnCollision(List<CollisionInfo> collisions)


### PR DESCRIPTION
Cause of bug: If an updateable causes some other updateable to be destroyed in it's update method, this messes up the loop that calls all of the update methods. Solved by duplicating the update list before looping.

Also: fixed that I forgot to remove the colliders of the sword beam burst after destruction