### PR TITLE
Enemy Flashing / Damage Update

### DIFF
--- a/Enemies/Aquamentus.cs
+++ b/Enemies/Aquamentus.cs
@@ -6,13 +6,13 @@ namespace LegendOfZelda
     public class Aquamentus : IEnemy
     {
         private readonly AnimatedSprite Sprite;
-        private int Health { get; set; } = 1;
+        private float Health = 6.0f;
         private Vector2 Position;
         private int CycleCount = 0;
         private readonly int MaxCycles = 50;
         private int PosIncrement = 2;
+        private float currentCooldown = 0.0f;
         public RectCollider Collider { get; private set; }
-
         public Aquamentus(Vector2 pos)
         {
             Position = pos;
@@ -39,7 +39,7 @@ namespace LegendOfZelda
             if (CycleCount > MaxCycles)
             {
                 CycleCount = 0;
-                PosIncrement *= -1;
+                PosIncrement = (int)(PosIncrement * -0.5);
             }
             Position.X += PosIncrement;
             CycleCount++;
@@ -53,9 +53,19 @@ namespace LegendOfZelda
             new AquamentusBall(Position, new Vector2(-10, 10));
             new AquamentusBall(Position, new Vector2(-10, -10));
         }
-        public void UpdateHealth(int damagePoints)
+        public void UpdateHealth(float damagePoints)
         {
-            // Not needed
+            Health -= damagePoints;
+
+            // Indicate damage, or if health has reached 0, die
+            if (Health < 0)
+            {
+                Die();
+            }
+            else
+            {
+                Sprite.blinking = true;
+            }
         }
 
         public void ChangeDirection()
@@ -67,6 +77,7 @@ namespace LegendOfZelda
 
         public void Update(GameTime gameTime)
         {
+            currentCooldown -= (float)gameTime.ElapsedGameTime.TotalSeconds; // Decrement the cooldown timer
             ChangePosition();
             if (CycleCount == MaxCycles)
             {
@@ -93,7 +104,11 @@ namespace LegendOfZelda
                 }
                 else if (collidedWith == CollisionLayer.PlayerWeapon)
                 {
-                    UpdateHealth(1); // Choose different values for each type of player weapon
+                    if (currentCooldown <= 0)
+                    {
+                        UpdateHealth(1.0f); // Choose different values for each type of player weapon
+                        currentCooldown = EnemyUtilities.DAMAGE_COOLDOWN; // Reset the cooldown timer
+                    }
                 }
             }
         }

--- a/Enemies/Bat.cs
+++ b/Enemies/Bat.cs
@@ -6,7 +6,7 @@ namespace LegendOfZelda
     public class Bat : IEnemy
     {
         private readonly SimpleEnemyStateMachine StateMachine;
-        private int Health { get; set; } = 1;
+        private float Health { get; set; } = 0.5f;
         public Vector2 Position;
         public Vector2 Offset = new Vector2(0, 16);
         public RectCollider Collider { get; private set; }
@@ -27,7 +27,6 @@ namespace LegendOfZelda
         }
         public void Spawn()
         {
-            new EnemySpawnEffect(Position);
             StateMachine.Spawn();
         }
         public void ChangePosition()
@@ -38,7 +37,7 @@ namespace LegendOfZelda
         {
             StateMachine.Attack();
         }
-        public void UpdateHealth(int damagePoints)
+        public void UpdateHealth(float damagePoints)
         {
             StateMachine.UpdateHealth(damagePoints);
         }
@@ -51,8 +50,6 @@ namespace LegendOfZelda
         public void Die()
         {
             StateMachine.Die();
-            Collider.Active = false;
-            new EnemyDeathEffect(Position);
         }
 
         public void Update(GameTime gameTime)

--- a/Enemies/BladeTrap.cs
+++ b/Enemies/BladeTrap.cs
@@ -31,7 +31,7 @@ namespace LegendOfZelda
             Sprite.UnregisterSprite();
             Collider.Active = false;
         }
-        public void UpdateHealth(int damagePoints) {}
+        public void UpdateHealth(float damagePoints) {}
 
         public void Attack() {}
 

--- a/Enemies/Dodongo.cs
+++ b/Enemies/Dodongo.cs
@@ -9,12 +9,13 @@ namespace LegendOfZelda
         private readonly List<AnimatedSprite> Sprites;
         private readonly List<AnimatedSprite> HurtSprites;
         private int CurrentSprite;
-        private int Health { get; set; } = 1;
+        private float Health { get; set; } = 8.0f;
         public Vector2 Position;
         private Vector2 Direction;
         private double LastSwitch = 0;
         private int UpdateCount = 0;
         private bool Injured = false;
+        private float currentCooldown = 0.0f;
         public RectCollider Collider { get; private set; }
         public Dodongo(Vector2 pos)
         {
@@ -73,19 +74,29 @@ namespace LegendOfZelda
             Collider.Pos = Position;
         }
         public void Attack() {}
-        public void UpdateHealth(int damagePoints)
+        public void UpdateHealth(float damagePoints)
         {
-            Sprites[CurrentSprite].UnregisterSprite();
-            if (!Injured)
+            Health -= damagePoints;
+
+            // Indicate damage, or if health has reached 0, die
+            if (Health < 0)
             {
-                Sprites[CurrentSprite] = HurtSprites[CurrentSprite];
+                Die();
             }
             else
             {
-                Sprites[CurrentSprite] = Sprites[CurrentSprite];
+                if (!Injured)
+                {
+                    Sprites[CurrentSprite] = HurtSprites[CurrentSprite];
+                    Sprites[CurrentSprite].blinking = true;
+                }
+                else
+                {
+                    Sprites[CurrentSprite] = Sprites[CurrentSprite];
+                }
+                Sprites[CurrentSprite].UpdatePos(Position);
+                Injured = !Injured;
             }
-            Sprites[CurrentSprite].UpdatePos(Position);
-            Injured = !Injured;
         }
 
         public void ChangeDirection()
@@ -145,7 +156,11 @@ namespace LegendOfZelda
                 }
                 else if (collidedWith == CollisionLayer.PlayerWeapon)
                 {
-                    UpdateHealth(1); // Choose different values for each type of player weapon
+                    if (currentCooldown <= 0)
+                    {
+                        UpdateHealth(1.0f); // Choose different values for each type of player weapon
+                        currentCooldown = EnemyUtilities.DAMAGE_COOLDOWN; // Reset the cooldown timer
+                    }
                 }
             }
         }

--- a/Enemies/EnemyUtilities.cs
+++ b/Enemies/EnemyUtilities.cs
@@ -1,0 +1,9 @@
+﻿namespace LegendOfZelda
+{
+    // This class will soon be expanded to encapsulate commonly used code / constants for enemies
+    // It is a primitive start for now, but I thought I'd establish it now. - MDC 10/25/23
+    public class EnemyUtilities
+    {
+       public static readonly float DAMAGE_COOLDOWN = 1.0f; // Adjust the delay duration as needed
+    }
+}

--- a/Enemies/GelSmall.cs
+++ b/Enemies/GelSmall.cs
@@ -6,7 +6,7 @@ namespace LegendOfZelda
     public class GelSmall : IEnemy
     {
         private readonly SimpleEnemyStateMachine StateMachine;
-        private int Health { get; set; } = 1;
+        private float Health { get; set; } = 0.5f;
         public Vector2 Position;
         public Vector2 Offset = new Vector2(0,0);
         public RectCollider Collider { get; private set; }
@@ -28,7 +28,6 @@ namespace LegendOfZelda
         }
         public void Spawn()
         {
-            new EnemySpawnEffect(Position);
             StateMachine.Spawn();
         }
         public void ChangePosition()
@@ -39,7 +38,7 @@ namespace LegendOfZelda
         {
             StateMachine.Attack();
         }
-        public void UpdateHealth(int damagePoints)
+        public void UpdateHealth(float damagePoints)
         {
             StateMachine.UpdateHealth(damagePoints);
         }
@@ -51,8 +50,6 @@ namespace LegendOfZelda
         public void Die()
         {
             StateMachine.Die();
-            Collider.Active = false;
-            new EnemyDeathEffect(Position);
         }
 
         public void Update(GameTime gameTime)

--- a/Enemies/Goriya.cs
+++ b/Enemies/Goriya.cs
@@ -8,11 +8,12 @@ namespace LegendOfZelda
     {
         private readonly List<AnimatedSprite> GoriyaSprites;
         private int CurrentSprite;
-        private int Health { get; set; } = 1;
+        private float Health { get; set; } = 3.0f;
         public Vector2 Position;
         private Vector2 Direction;
         private double LastSwitch = 0;
         private int UpdateCount = 0;
+        private float currentCooldown = 0.0f;
         public RectCollider Collider { get; private set; }
         public Goriya(Vector2 pos)
         {
@@ -60,12 +61,19 @@ namespace LegendOfZelda
         {
             new GoriyaBoomerang(Position, Direction * 3);
         }
-        public void UpdateHealth(int damagePoints)
+        public void UpdateHealth(float damagePoints)
         {
-            /* 
-             * This isn't needed for Sprint 2,
-             * however it will be needed later.
-             */
+            Health -= damagePoints;
+
+            // Indicate damage, or if health has reached 0, die
+            if (Health < 0)
+            {
+                Die();
+            }
+            else
+            {
+                GoriyaSprites[CurrentSprite].blinking = true;
+            }
         }
 
         public void ChangeDirection()
@@ -104,6 +112,7 @@ namespace LegendOfZelda
 
         public void Update(GameTime gameTime)
         {
+            currentCooldown -= (float)gameTime.ElapsedGameTime.TotalSeconds; // Decrement the cooldown timer
             if (gameTime.TotalGameTime.TotalMilliseconds > LastSwitch + 1000)
             {
                 LastSwitch = gameTime.TotalGameTime.TotalMilliseconds;
@@ -130,7 +139,11 @@ namespace LegendOfZelda
                 }
                 else if (collidedWith == CollisionLayer.PlayerWeapon)
                 {
-                    UpdateHealth(1); // Choose different values for each type of player weapon
+                    if (currentCooldown <= 0)
+                    {
+                        UpdateHealth(1.0f); // Choose different values for each type of player weapon
+                        currentCooldown = EnemyUtilities.DAMAGE_COOLDOWN; // Reset the cooldown timer
+                    }
                 }
             }
         }

--- a/Enemies/Rope.cs
+++ b/Enemies/Rope.cs
@@ -1,16 +1,18 @@
 ﻿using Microsoft.Xna.Framework;
 using System.Collections.Generic;
+using System.Reflection.Emit;
 
 namespace LegendOfZelda
 {
     public class Rope : IEnemy
     {
         private AnimatedSprite Sprite;
-        private int Health { get; set; } = 1;
+        private float Health { get; set; } = 0.5f;
         public Vector2 Position;
         private readonly int PosIncrement = 5;
         private bool FacingLeft = false;
         private double LastSwitch = 0;
+        private float currentCooldown = 0.0f;
         public RectCollider Collider { get; private set; }
         public Rope(Vector2 pos)
         {
@@ -48,7 +50,19 @@ namespace LegendOfZelda
             Collider.Pos = Position;
         }
         public void Attack() {}
-        public void UpdateHealth(int damagePoints) {}
+        public void UpdateHealth(float damagePoints) {
+            Health -= damagePoints;
+
+            // Indicate damage, or if health has reached 0, die
+            if (Health < 0)
+            {
+                Die();
+            }
+            else
+            {
+                Sprite.blinking = true;
+            }
+        }
 
         public void ChangeDirection()
         {
@@ -69,6 +83,7 @@ namespace LegendOfZelda
 
         public void Update(GameTime gameTime)
         {
+            currentCooldown -= (float)gameTime.ElapsedGameTime.TotalSeconds; // Decrement the cooldown timer
             if (gameTime.TotalGameTime.TotalMilliseconds > LastSwitch + 1000)
             {
                 LastSwitch = gameTime.TotalGameTime.TotalMilliseconds;
@@ -97,7 +112,11 @@ namespace LegendOfZelda
                 }
                 else if (collidedWith == CollisionLayer.PlayerWeapon)
                 {
-                    UpdateHealth(1); // Choose different values for each type of player weapon
+                    if (currentCooldown <= 0)
+                    {
+                        UpdateHealth(1.0f); // Choose different values for each type of player weapon
+                        currentCooldown = EnemyUtilities.DAMAGE_COOLDOWN; // Reset the cooldown timer
+                    }
                 }
             }
         }

--- a/Enemies/SimpleEnemyStateMachine.cs
+++ b/Enemies/SimpleEnemyStateMachine.cs
@@ -10,11 +10,12 @@ namespace LegendOfZelda
         public enum Speed { slow, medium, fast };
         public Speed EnemySpeed { get; set; }
         public int SpeedMultiplier;
-        public int Health { get; set; }
+        public float Health { get; set; }
         private Vector2 Position;
         private Vector2 Offset;
         private Vector2 Direction;
         private double LastSwitch = 0;
+        private float currentCooldown = 0.0f;
         public RectCollider Collider { get; set; }
 
         public SimpleEnemyStateMachine(Vector2 pos, Vector2 offset, RectCollider collider)
@@ -36,13 +37,7 @@ namespace LegendOfZelda
             }
             Collider = collider;
         }
-        public void Attack()
-        {
-            /* 
-            * This isn't needed for Sprint 2,
-            * however it will be needed later.
-            */
-        }
+        public void Attack() {}
 
         public void ChangeDirection()
         {
@@ -81,12 +76,14 @@ namespace LegendOfZelda
         {
             Sprite.UpdatePos(Position);
             Collider.Active = false;
+            new EnemyDeathEffect(Position);
             Sprite.UnregisterSprite();
             LevelMaster.RemoveUpdateable(this);
         }
 
         public void Spawn()
         {
+            new EnemySpawnEffect(Position);
             LevelMaster.RegisterUpdateable(this);
             Sprite.RegisterSprite();
             Sprite.UpdatePos(Position);
@@ -95,7 +92,7 @@ namespace LegendOfZelda
 
         public void Update(GameTime gameTime)
         {
-
+            currentCooldown -= (float)gameTime.ElapsedGameTime.TotalSeconds;
             if (gameTime.TotalGameTime.TotalMilliseconds > LastSwitch + 1000)
             {
                 LastSwitch = gameTime.TotalGameTime.TotalMilliseconds;
@@ -105,7 +102,7 @@ namespace LegendOfZelda
             Collider.Pos = Position + Offset;
         }
 
-        public void UpdateHealth(int damagePoints)
+        public void UpdateHealth(float damagePoints)
         {
             Health -= damagePoints;
 
@@ -117,7 +114,6 @@ namespace LegendOfZelda
             {
                 Sprite.blinking = true;
             }
-            Sprite.blinking = false;
         }
 
         public void OnCollision(List<CollisionInfo> collisions) {
@@ -131,7 +127,11 @@ namespace LegendOfZelda
                 }
                 else if (collidedWith == CollisionLayer.PlayerWeapon)
                 {
-                    UpdateHealth(1); // Choose different values for each type of player weapon
+                    if (currentCooldown <= 0)
+                    {
+                        UpdateHealth(1.0f); // Choose different values for each type of player weapon
+                        currentCooldown = EnemyUtilities.DAMAGE_COOLDOWN; // Reset the cooldown timer
+                    }
                 }
             }
         }

--- a/Enemies/Skeleton.cs
+++ b/Enemies/Skeleton.cs
@@ -6,7 +6,7 @@ namespace LegendOfZelda
     public class Skeleton : IEnemy
     {
         private readonly SimpleEnemyStateMachine StateMachine;
-        private int Health { get; set; } = 1;
+        private float Health { get; set; } = 2.0f;
         public Vector2 Position;
         public Vector2 Offset = new Vector2(0, 0);
         public RectCollider Collider { get; private set; }
@@ -28,7 +28,6 @@ namespace LegendOfZelda
         }
         public void Spawn()
         {
-            new EnemySpawnEffect(Position);
             StateMachine.Spawn();
         }
         public void ChangePosition()
@@ -39,7 +38,7 @@ namespace LegendOfZelda
         {
             StateMachine.Attack();
         }
-        public void UpdateHealth(int damagePoints)
+        public void UpdateHealth(float damagePoints)
         {
             StateMachine.UpdateHealth(damagePoints);
         }
@@ -51,8 +50,6 @@ namespace LegendOfZelda
         public void Die()
         {
             StateMachine.Die();
-            Collider.Active = false;
-            new EnemyDeathEffect(Position);
         }
 
         public void Update(GameTime gameTime)

--- a/Enemies/Wallmaster.cs
+++ b/Enemies/Wallmaster.cs
@@ -6,7 +6,7 @@ namespace LegendOfZelda
     public class WallMaster : IEnemy
     {
         private readonly SimpleEnemyStateMachine StateMachine;
-        private int Health { get; set; } = 1;
+        private float Health { get; set; } = 1.0f;
         public Vector2 Position;
         public Vector2 Offset = new Vector2(0, 0);
         public RectCollider Collider { get; private set; }
@@ -28,7 +28,6 @@ namespace LegendOfZelda
         }
         public void Spawn()
         {
-            new EnemySpawnEffect(Position);
             StateMachine.Spawn();
         }
         public void ChangePosition()
@@ -39,7 +38,7 @@ namespace LegendOfZelda
         {
             StateMachine.Attack();
         }
-        public void UpdateHealth(int damagePoints)
+        public void UpdateHealth(float damagePoints)
         {
             StateMachine.UpdateHealth(damagePoints);
         }
@@ -51,8 +50,6 @@ namespace LegendOfZelda
         public void Die()
         {
             StateMachine.Die();
-            Collider.Active = false;
-            new EnemyDeathEffect(Position);
         }
 
         public void Update(GameTime gameTime)

--- a/Enemies/Wizard.cs
+++ b/Enemies/Wizard.cs
@@ -6,8 +6,9 @@ namespace LegendOfZelda
     public class Wizard : IEnemy
     {
         private readonly AnimatedSprite Sprite;
-        private int Health { get; set; } = 1;
+        private float Health { get; set; } = 1.0f;
         public Vector2 Position;
+        private float currentCooldown = 0.0f;
         public RectCollider Collider { get; private set; }
 
         public Wizard(Vector2 pos)
@@ -33,11 +34,8 @@ namespace LegendOfZelda
         {
             // Mechanics of this attack can be changed later
             new FireProjectile(Position, Direction.right);
-            new FireProjectile(Position, Direction.left);
-            new FireProjectile(Position, Direction.down);
-            new FireProjectile(Position, Direction.up);
         }
-        public void UpdateHealth(int damagePoints) {}
+        public void UpdateHealth(float damagePoints) {}
 
         public void ChangeDirection() {}
         public void Die()
@@ -47,7 +45,9 @@ namespace LegendOfZelda
             LevelMaster.RemoveUpdateable(this);
         }
 
-        public void Update(GameTime gameTime) {}
+        public void Update(GameTime gameTime) {
+            currentCooldown -= (float)gameTime.ElapsedGameTime.TotalSeconds; // Decrement the cooldown timer
+        }
 
         public void OnCollision(List<CollisionInfo> collisions)
         {
@@ -56,8 +56,11 @@ namespace LegendOfZelda
                 CollisionLayer collidedWith = collision.CollidedWith.Layer;
                 if (collidedWith == CollisionLayer.PlayerWeapon)
                 {
-                    UpdateHealth(1); // Choose different values for each type of player weapon
-                    Attack();
+                    if (currentCooldown <= 0)
+                    {
+                        UpdateHealth(1.0f); // Choose different values for each type of player weapon
+                        currentCooldown = EnemyUtilities.DAMAGE_COOLDOWN; // Reset the cooldown timer
+                    }
                 }
             }
         }

--- a/Enemies/ZolBig.cs
+++ b/Enemies/ZolBig.cs
@@ -6,7 +6,7 @@ namespace LegendOfZelda
     public class ZolBig : IEnemy
     {
         private readonly SimpleEnemyStateMachine StateMachine;
-        private int Health { get; set; } = 1;
+        private float Health { get; set; } = 2.0f;
         public Vector2 Position;
         public Vector2 Offset = new Vector2(0, 0);
         public RectCollider Collider { get; private set; }
@@ -28,7 +28,6 @@ namespace LegendOfZelda
         }
         public void Spawn()
         {
-            new EnemySpawnEffect(Position);
             StateMachine.Spawn();
         }
         public void ChangePosition()
@@ -39,7 +38,7 @@ namespace LegendOfZelda
         {
             StateMachine.Attack();
         }
-        public void UpdateHealth(int damagePoints)
+        public void UpdateHealth(float damagePoints)
         {
             StateMachine.UpdateHealth(damagePoints);
         }
@@ -51,8 +50,6 @@ namespace LegendOfZelda
         public void Die()
         {
             StateMachine.Die();
-            Collider.Active = false;
-            new EnemyDeathEffect(Position);
         }
 
         public void Update(GameTime gameTime)

--- a/Interfaces/IEnemy.cs
+++ b/Interfaces/IEnemy.cs
@@ -7,7 +7,7 @@ namespace LegendOfZelda
     public interface IEnemy: IUpdateable, ICollidable
     {
         void Spawn();
-        void UpdateHealth(int damagePoints);
+        void UpdateHealth(float damagePoints);
         void Attack();
         void ChangePosition();
         void ChangeDirection();


### PR DESCRIPTION
All enemy health has been updated according to the values on https://gamefaqs.gamespot.com/boards/563433-the-legend-of-zelda/50876050. Added functionality so there is a delay in enemies taking damage for the collision. This makes it so enemies dont die on one hit every time, since collisions are updated and registered per frame.

Closes #209 