### PR TITLE
Add game over screen

### DIFF
--- a/GameState/GameOverState.cs
+++ b/GameState/GameOverState.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace LegendOfZelda
+{
+    internal class GameOverState : IGameState
+    {
+        private GameOverScreen gameOver;
+
+        public GameOverState()
+        {
+            gameOver = new GameOverScreen();
+        }
+        public void Update(GameTime gameTime)
+        {
+            gameOver.Update(gameTime);
+        }
+        public void Draw(SpriteBatch _spriteBatch)
+        {
+            GameState.CameraController.Draw(_spriteBatch);
+        }
+    }
+}

--- a/GameState/GameState.cs
+++ b/GameState/GameState.cs
@@ -51,12 +51,12 @@ namespace LegendOfZelda
         {
             State.Update(gameTime);
 
-            // this portion solely for testing with winning state
-            //if (gameTime.TotalGameTime.TotalMilliseconds > 3000 && !AlreadySwitched)
-            //{
-            //    SwitchState(new WinningState());
-            //    AlreadySwitched = true;
-            //}
+            // Uncomment the part below to test game over screen
+            /*if (gameTime.TotalGameTime.TotalMilliseconds > 3000 && !AlreadySwitched)
+            {
+                SwitchState(new GameOverState());
+                AlreadySwitched = true;
+            }*/
         }
         public void Draw(SpriteBatch _spriteBatch)
         {

--- a/LegendOfZelda.csproj
+++ b/LegendOfZelda.csproj
@@ -18,6 +18,7 @@
     <None Remove="Code Review\**" />
     <None Remove="LegendOfZelda\**" />
     <Compile Remove="LinkCommand.cs" />
+    <None Remove="Utility\GameOverScreen\" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Icon.ico" />
@@ -38,6 +39,7 @@
     <Folder Include="GameInterface\" />
     <Folder Include="LegendOfZelda\obj\Release\" />
     <Folder Include="ItemClasses\" />
+    <Folder Include="Utility\GameOverScreen\" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Level\Levels\level1.json">

--- a/Utility/GameOverScreen/BlackScreen.cs
+++ b/Utility/GameOverScreen/BlackScreen.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace LegendOfZelda
+{
+	public class BlackScreen : IDrawable
+	{
+        private Texture2D overlay;
+        private Game1 game;
+        private Rectangle overlayTexture;
+        private GraphicsDevice graphicsDevice;
+        private SpriteBatch spriteBatch;
+        private int CameraXPos;
+        private int CameraYPos;
+
+        public BlackScreen()
+		{
+            game = Game1.getInstance();
+            graphicsDevice = game.GraphicsDevice;
+            overlay = SpriteFactory.getInstance().linkTexture;
+            overlayTexture = new Rectangle(118, 64, 1, 1);
+            spriteBatch = game._spriteBatch;
+            CameraXPos = (int)GameState.CameraController.mainCamera.worldPos.X;
+            CameraYPos = (int)GameState.CameraController.mainCamera.worldPos.Y;
+        }
+
+        public void Draw()
+        {
+            spriteBatch.Draw(overlay, new Rectangle(CameraXPos, CameraYPos, graphicsDevice.Viewport.Width, graphicsDevice.Viewport.Height), overlayTexture, Color.Black);
+        }
+    }
+}
+

--- a/Utility/GameOverScreen/DarkRed.cs
+++ b/Utility/GameOverScreen/DarkRed.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace LegendOfZelda
+{
+	public class DarkRed : IDrawable
+	{
+        private Texture2D overlay;
+        private Game1 game;
+        private Rectangle overlayTexture;
+        private GraphicsDevice graphicsDevice;
+        private SpriteBatch spriteBatch;
+        private int CameraXPos;
+        private int CameraYPos;
+        private Color color;
+
+        public DarkRed()
+		{
+            game = Game1.getInstance();
+            graphicsDevice = game.GraphicsDevice;
+            overlay = SpriteFactory.getInstance().linkTexture;
+            overlayTexture = new Rectangle(118, 64, 1, 1);
+            spriteBatch = game._spriteBatch;
+            CameraXPos = (int)GameState.CameraController.mainCamera.worldPos.X;
+            CameraYPos = (int)GameState.CameraController.mainCamera.worldPos.Y;
+            color = new Color(300, 0, 0, 50);
+        }
+
+        public void Draw()
+        {
+            spriteBatch.Draw(overlay, new Rectangle(CameraXPos, CameraYPos, graphicsDevice.Viewport.Width, graphicsDevice.Viewport.Height), overlayTexture, color);
+        }
+    }
+}
+

--- a/Utility/GameOverScreen/GameOverScreen.cs
+++ b/Utility/GameOverScreen/GameOverScreen.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+namespace LegendOfZelda
+{
+	public class GameOverScreen : IUpdateable
+	{
+		private LinkSpinningOverlay linkSpinningOverlay;
+		private LightRed lightRed;
+		private NormalRed red;
+		private DarkRed darkRed;
+		private BlackScreen blackScreen;
+		private GameOverText text;
+		private double lastUpdate;
+		private int counter;
+
+		public GameOverScreen()
+		{
+			linkSpinningOverlay = new LinkSpinningOverlay();
+			lightRed = new LightRed();
+			red = new NormalRed();
+			darkRed = new DarkRed();
+			blackScreen = new BlackScreen();
+			text = new GameOverText();
+			lastUpdate = 0;
+			counter = 0;
+        }
+
+		public void ActivateGameOver()
+		{
+			LevelMaster.RegisterUpdateable(this);
+		}
+
+		private void DrawLinkSpinningOverlay()
+		{
+			LevelMaster.RegisterDrawable(linkSpinningOverlay);
+        }
+
+		private void DrawLightRed()
+		{
+			LevelMaster.RegisterDrawable(lightRed);
+        }
+
+		private void DrawNormalRed()
+		{
+			LevelMaster.RegisterDrawable(red);
+        }
+
+		private void DrawDarkRed()
+		{
+			LevelMaster.RegisterDrawable(darkRed);
+        }
+
+		private void DrawBlackScreen()
+		{
+			LevelMaster.RegisterDrawable(blackScreen);
+        }
+
+		private void WriteWord()
+		{
+			LevelMaster.RegisterDrawable(text);
+        }
+
+		public void Update(GameTime gameTime)
+		{
+			if ((counter == 0) && (gameTime.TotalGameTime.TotalMilliseconds > lastUpdate + 100))
+            {
+				DrawLinkSpinningOverlay();
+                lastUpdate = gameTime.TotalGameTime.TotalMilliseconds;
+                counter++;
+			}
+
+			/* The length of overlay where link is spinning is tentatively set to 3000, this should always be
+			 * synchronized with Link to make sure LinkSpinningState and this screen have the same length.
+			 */
+            if ((counter == 1) && (gameTime.TotalGameTime.TotalMilliseconds > lastUpdate + 3000))
+			{
+				DrawLightRed();
+                lastUpdate = gameTime.TotalGameTime.TotalMilliseconds;
+				counter++;
+            }
+
+            if ((counter == 2) && (gameTime.TotalGameTime.TotalMilliseconds > lastUpdate + 500))
+			{
+				DrawNormalRed();
+				lastUpdate = gameTime.TotalGameTime.TotalMilliseconds;
+				counter++;
+			}
+
+            if ((counter == 3) && (gameTime.TotalGameTime.TotalMilliseconds > lastUpdate + 500))
+			{
+				DrawDarkRed();
+				lastUpdate = gameTime.TotalGameTime.TotalMilliseconds;
+				counter++;
+			}
+
+			/* Link should become black & white at this moment, when screen turns black, which is 4100 milliseconds
+			 * after gameover screen starts to draw. This is a tentative number based on the time I used now.
+			 */
+			if ((counter == 4) && (gameTime.TotalGameTime.TotalMilliseconds > lastUpdate + 500))
+			{
+				DrawBlackScreen();
+				lastUpdate = gameTime.TotalGameTime.TotalMilliseconds;
+				counter++;
+			}
+
+			/* Link dissapearing animation should finish before word is written, 
+			 * once again 800 here is a tentative time.
+			 */
+			if ((counter == 5) && (gameTime.TotalGameTime.TotalMilliseconds > lastUpdate + 2000))
+			{
+				WriteWord();
+				counter++;
+			}
+
+        }
+	}
+}
+

--- a/Utility/GameOverScreen/GameOverText.cs
+++ b/Utility/GameOverScreen/GameOverText.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace LegendOfZelda
+{
+	public class GameOverText : IDrawable
+	{
+        private Game1 game;
+        private GraphicsDevice graphicsDevice;
+        private SpriteBatch spriteBatch;
+        private int CameraXPos;
+        private int CameraYPos;
+
+        public GameOverText()
+		{
+            game = Game1.getInstance();
+            graphicsDevice = game.GraphicsDevice;
+            spriteBatch = game._spriteBatch;
+            CameraXPos = (int)GameState.CameraController.mainCamera.worldPos.X;
+            CameraYPos = (int)GameState.CameraController.mainCamera.worldPos.Y;
+        }
+
+        public void Draw()
+        {
+            spriteBatch.DrawString(SpriteFactory.getInstance().pauseWord, "GAME OVER", new Vector2(CameraXPos + (graphicsDevice.Viewport.Width / 2) - 70, CameraYPos + (graphicsDevice.Viewport.Height / 2) - 20), Color.White);
+        }
+    }
+}
+

--- a/Utility/GameOverScreen/LightRed.cs
+++ b/Utility/GameOverScreen/LightRed.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace LegendOfZelda
+{
+	public class LightRed : IDrawable
+	{
+        private Texture2D overlay;
+        private Game1 game;
+        private Rectangle overlayTexture;
+        private GraphicsDevice graphicsDevice;
+        private SpriteBatch spriteBatch;
+        private int CameraXPos;
+        private int CameraYPos;
+        private Color color;
+
+        public LightRed()
+		{
+            game = Game1.getInstance();
+            graphicsDevice = game.GraphicsDevice;
+            overlay = SpriteFactory.getInstance().linkTexture;
+            overlayTexture = new Rectangle(118, 64, 1, 1);
+            spriteBatch = game._spriteBatch;
+            CameraXPos = (int)GameState.CameraController.mainCamera.worldPos.X;
+            CameraYPos = (int)GameState.CameraController.mainCamera.worldPos.Y;
+            color = new Color(150, 0, 0, 30);
+        }
+
+        public void Draw()
+        {
+            spriteBatch.Draw(overlay, new Rectangle(CameraXPos, CameraYPos, graphicsDevice.Viewport.Width, graphicsDevice.Viewport.Height), overlayTexture, color);
+        }
+    }
+}
+

--- a/Utility/GameOverScreen/LinkSpinningOverlay.cs
+++ b/Utility/GameOverScreen/LinkSpinningOverlay.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace LegendOfZelda
+{
+	public class LinkSpinningOverlay : IDrawable
+	{
+        private Texture2D overlay;
+        private Game1 game;
+        private Rectangle overlayTexture;
+        private GraphicsDevice graphicsDevice;
+        private SpriteBatch spriteBatch;
+        private int CameraXPos;
+        private int CameraYPos;
+        private Color color;
+
+        public LinkSpinningOverlay()
+		{
+            game = Game1.getInstance();
+            graphicsDevice = game.GraphicsDevice;
+            overlay = SpriteFactory.getInstance().linkTexture;
+            overlayTexture = new Rectangle(118, 64, 1, 1);
+            spriteBatch = game._spriteBatch;
+            CameraXPos = (int)GameState.CameraController.mainCamera.worldPos.X;
+            CameraYPos = (int)GameState.CameraController.mainCamera.worldPos.Y;
+            color = new Color(200, 0, 0, 50);
+        }
+
+        public void Draw()
+        {
+            spriteBatch.Draw(overlay, new Rectangle(CameraXPos, CameraYPos, graphicsDevice.Viewport.Width, graphicsDevice.Viewport.Height), overlayTexture, color);
+        }
+    }
+}
+

--- a/Utility/GameOverScreen/NormalRed.cs
+++ b/Utility/GameOverScreen/NormalRed.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace LegendOfZelda
+{
+	public class NormalRed : IDrawable
+	{
+        private Texture2D overlay;
+        private Game1 game;
+        private Rectangle overlayTexture;
+        private GraphicsDevice graphicsDevice;
+        private SpriteBatch spriteBatch;
+        private int CameraXPos;
+        private int CameraYPos;
+        private Color color;
+
+        public NormalRed()
+		{
+            game = Game1.getInstance();
+            graphicsDevice = game.GraphicsDevice;
+            overlay = SpriteFactory.getInstance().linkTexture;
+            overlayTexture = new Rectangle(118, 64, 1, 1);
+            spriteBatch = game._spriteBatch;
+            CameraXPos = (int)GameState.CameraController.mainCamera.worldPos.X;
+            CameraYPos = (int)GameState.CameraController.mainCamera.worldPos.Y;
+            color = new Color(255, 0, 0, 50);
+        }
+
+        public void Draw()
+        {
+            spriteBatch.Draw(overlay, new Rectangle(CameraXPos, CameraYPos, graphicsDevice.Viewport.Width, graphicsDevice.Viewport.Height), overlayTexture, color);
+        }
+    }
+}
+

--- a/Utility/WinningScreen/WhiteFlash.cs
+++ b/Utility/WinningScreen/WhiteFlash.cs
@@ -27,7 +27,7 @@ namespace LegendOfZelda
 
 		public void Draw()
 		{
-            game._spriteBatch.Draw(overlay, new Rectangle((int)GameState.CameraController.mainCamera.worldPos.X, (int)GameState.CameraController.mainCamera.worldPos.Y, screenHeight, screenWidth), overlayTexture, Color.White);
+            game._spriteBatch.Draw(overlay, new Rectangle((int)GameState.CameraController.mainCamera.worldPos.X, (int)GameState.CameraController.mainCamera.worldPos.Y, screenWidth, screenHeight), overlayTexture, Color.White);
         }
 	}
 }


### PR DESCRIPTION
In this PR:
- Added classes for GameOver screen 
- Classes added cover the part of screen overlays, not link animations
- Added GameOverState, @EthanGlenwright775 should take a look to see if it meets the standard
- Length of time in which each overlay stays on the screen are all tentative, I'm open to any suggestions to make them corporate better with link animation
- Fixed a minor glitch in game winning screen

To Test:
Uncomment the specified part in GameState.cs, game over screen will start after 3 seconds