### PR TITLE
Turn off hitbox indicators

### DIFF
--- a/Collisions/RectCollider.cs
+++ b/Collisions/RectCollider.cs
@@ -15,7 +15,7 @@ namespace LegendOfZelda
         //The drawing functionality is added in this class because we want all RectColliders to have this capability
         //If we extended RectCollider we would have to change all RectColliders to the extended class and enforce it
         //This could be refactored in the future to use preprocessor directives with a debug mode instead
-        public static bool drawColliders = true;
+        public static bool drawColliders = false;
         private SpriteBatch spriteBatch;
         private Texture2D textureWithWhitePixel;
         private Rectangle locationOfWhitePixel;


### PR DESCRIPTION
Merging without approval because this PR simply toggles indicators off.