### PR TITLE
Fix green bar in main menu sprite

### DIFF
--- a/Graphics/SpriteFactory.cs
+++ b/Graphics/SpriteFactory.cs
@@ -1826,7 +1826,7 @@ namespace LegendOfZelda
         {
             Rectangle[] frames = new Rectangle[1]
             {
-                new Rectangle(0, 11, 256, 224),
+                new Rectangle(1, 11, 256, 224),
             };
 
             AnimatedSprite newSprite = new AnimatedSprite(menuTexture, frames, SpriteEffects.None, drawFramesPerAnimFrame, scale, true);


### PR DESCRIPTION
Start game, look at left side

I guess I can extend the sprite to fix the bar on the bottom due to us making the window a rectangle instead of a square, but I'll leave it for now.