### PR TITLE
Enemy knockback

### DIFF
--- a/Enemies/EnemyStateMachine.cs
+++ b/Enemies/EnemyStateMachine.cs
@@ -71,6 +71,56 @@ namespace LegendOfZelda
             enemy.Collider.Pos = enemy.Position + enemy.Offset;
         }
 
+        public static void ApplyKnockback(IEnemy enemy, Direction knockbackDirection)
+        {
+            Vector2 newDirection;
+
+            switch (knockbackDirection)
+            {
+                case Direction.up:
+                    newDirection = new(0, 1);
+                    break;
+                case Direction.down:
+                    newDirection = new(0, -1);
+                    break;
+                case Direction.left:
+                    newDirection = new(1, 0);
+                    break;
+                case Direction.right:
+                    newDirection = new(-1, 0);
+                    break;
+                case Direction.upLeft:
+                    newDirection = new(1, 1);
+                    break;
+                case Direction.upRight:
+                    newDirection = new(-1, 1);
+                    break;
+                case Direction.downLeft:
+                    newDirection = new(1, 1);
+                    break;
+                case Direction.downRight:
+                    newDirection = new(-1, -1);
+                    break;
+                default:
+                    newDirection = Vector2.Zero;
+                    break;
+            }
+
+            // Define knockback parameters
+            float knockbackDistance = 20.0f;
+            float knockbackSpeed = 1.0f;
+
+            // Calculate the target position after knockback
+            Vector2 targetPosition = enemy.Position + newDirection * knockbackDistance;
+
+            // Apply knockback using linear interpolation
+            enemy.Position = Vector2.Lerp(enemy.Position, targetPosition, knockbackSpeed);
+
+            // Update the sprite and collider positions
+            enemy.Sprite.UpdatePos(enemy.Position);
+            enemy.Collider.Pos = enemy.Position + enemy.Offset;
+        }
+
         public static void UpdateHealth(IEnemy enemy, float damagePoints)
         {
             enemy.Health -= damagePoints;
@@ -107,6 +157,7 @@ namespace LegendOfZelda
                     if (enemy.CurrentCooldown <= 0)
                     {
                         EnemyUtilities.HandleWeaponCollision(enemy, enemy.EnemyType, collision);
+                        ApplyKnockback(enemy, collision.EstimatedDirection);
                         enemy.CurrentCooldown = EnemyUtilities.DAMAGE_COOLDOWN; // Reset the cooldown timer
                         enemy.Sprite.flashing = true;
                         new Timer(1.0f, () => StopFlashing(enemy));

--- a/Enemies/EnemyStateMachine.cs
+++ b/Enemies/EnemyStateMachine.cs
@@ -107,7 +107,7 @@ namespace LegendOfZelda
             }
 
             // Define knockback parameters
-            float knockbackDistance = 20.0f;
+            float knockbackDistance = 30.0f;
             float knockbackSpeed = 1.0f;
 
             // Calculate the target position after knockback


### PR DESCRIPTION
Enemies have some knockback. Distance and speed at which this occurs can be adjusted. I found that sometimes if an enemy is hit near a wall, it may get stuck in the wall. I'm not quite sure how to remedy this, if you have a suggestion, lmk. Also ok if this doesn't go in since there is currently a known bug, it may be better to leave it the way it is than introduce a potentially new bug. I sat with it for a while before putting up this pr. lmk what you all think.